### PR TITLE
Audio quality improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,11 @@ CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
 SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
 
+export ITFILES	:=	$(foreach dir,$(notdir $(wildcard $(MUSIC)/*.it)),$(CURDIR)/$(MUSIC)/$(dir))
+export WAVFILES	:=	$(foreach dir,$(notdir $(wildcard $(MUSIC)/*.wav)),$(CURDIR)/$(MUSIC)/$(dir))
+
 ifneq ($(strip $(MUSIC)),)
-	export AUDIOFILES	:=	$(foreach dir,$(notdir $(wildcard $(MUSIC)/*.*)),$(CURDIR)/$(MUSIC)/$(dir))
+	export AUDIOFILES	:=	$(foreach dir,$(notdir $(wildcard $(MUSIC)/*.*)),$(CURDIR)/$(BUILD)/$(dir))
 	BINFILES += soundbank.bin
 endif
 
@@ -151,9 +154,13 @@ $(OFILES_SOURCES) : $(HFILES)
 #---------------------------------------------------------------------------------
 # rule to build soundbank from music files
 #---------------------------------------------------------------------------------
-soundbank.bin soundbank.h : $(AUDIOFILES)
+soundbank.bin soundbank.h : $(ITFILES)
 #---------------------------------------------------------------------------------
-	@mmutil $^ -osoundbank.bin -hsoundbank.h
+	@cp $(ITFILES) .
+	for i in $(WAVFILES) ; do \
+		sox $$i -b 8 `basename $$i` gain -1 channels 1 rate -I 31536 dither -s ; \
+	done
+	@mmutil $(AUDIOFILES) -v -osoundbank.bin -hsoundbank.h
 
 #---------------------------------------------------------------------------------
 # This rule links in binary data with the .bin extension

--- a/source/init.c
+++ b/source/init.c
@@ -68,9 +68,31 @@ void initIrq()
   irq_enable(II_VBLANK);
 }
 
+static void *maxmod_buffer = NULL;
+static uint8_t maxmod_mix_memory[MM_MIXLEN_31KHZ];
+
 void initMaxmod()
 {
-  mmInitDefault( (mm_addr)soundbank_bin, 8 );
+  if (maxmod_buffer != NULL)
+    free(maxmod_buffer);
+
+  uint8_t channels = 8;
+  uint16_t mix_len = MM_MIXLEN_31KHZ;
+  mm_gba_system sys;
+
+  maxmod_buffer = malloc(mix_len + (channels * (MM_SIZEOF_MODCH + MM_SIZEOF_ACTCH + MM_SIZEOF_MIXCH)));
+
+  sys.mixing_mode = MM_MIX_31KHZ;
+  sys.mod_channel_count = channels;
+  sys.mix_channel_count = channels;
+  sys.wave_memory = (mm_addr) (maxmod_buffer);
+  sys.module_channels = (mm_addr) (maxmod_buffer + mix_len);
+  sys.active_channels = (mm_addr) (maxmod_buffer + mix_len + (channels * (MM_SIZEOF_MODCH)));
+  sys.mixing_channels = (mm_addr) (maxmod_buffer + mix_len + (channels * (MM_SIZEOF_MODCH + MM_SIZEOF_ACTCH)));
+  sys.mixing_memory = maxmod_mix_memory;
+  sys.soundbank = (mm_addr)soundbank_bin;
+
+  mmInit(&sys);
   mmSetVBlankHandler(irqvector);
   mmSetModuleVolume(256);
 }


### PR DESCRIPTION
* Use highest-quality 31KHz maxmod mixing.
* Pre-downsample/mix WAV files with SoX instead of relying on the GBA to do it; this should slightly improve quality, as well as save ~200KB of ROM size (though I also upsample the other WAV files, technically).